### PR TITLE
Drogue parachute mach lock based on MPU's accelerometer

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -34,3 +34,9 @@ typedef struct Result {
     String message;
 
 } Result;
+
+typedef struct TimeData {
+    unsigned long timeNow = 0UL;
+    unsigned long timePrev = 0UL;
+    unsigned long dt = 0UL; // loop time used to update integral 
+} TimeData;

--- a/include/params/setup_params.h
+++ b/include/params/setup_params.h
@@ -27,3 +27,9 @@
 
 #define PinSrc 1 // FIX, continuity check pin, input
 #define PinGnd 1 // FIX, continuity check pin, output
+
+#define MICROS_TO_SECONDS 0.000001f // 1 us = 10^(-6) s
+#define G_TO_SI_UNITS 9.80665f // 1 g-unit = 9.80665 m/s^2
+
+#define Y_ACCEL_INDEX 1 // Index of y-axis acceleration in acceleration vector
+#define SUBSONIC_SPEED 205.8f // Units: m/s (343 m/s = Mach 1)


### PR DESCRIPTION
I added Mach immunity using the MPU's accelerometer. The vertical velocity is calculated using the y-axis acceleration data. In order for the drogue parachute to deploy, this velocity must be less than than **SUBSONIC_SPEED** (which has been defined under setup_params.h).

- The **loopTimer** variable measures the main loop's time interval.
- **loopTimer** is reset on every loop cycle
- The **TimeData** struct stores the value of this time interval in the **dt** member.
- **avg_y_accel** stores the average y-axis acceleration based on the 3 most recent Samples.
- **mpuVelY** is the vertical velocity based on the integration of **avg_y_accel**
- Added the conditional statement **mpuVelY < SUBSONIC_SPEED** to avoid deployment of the drogue parachute if the  vertical velocity is too high ( and possibly in the transonic range)

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>